### PR TITLE
Add system_state dbus property

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -12,3 +12,7 @@ host:
         name: boot_flags
         type: s
         default: "0000000000"
+    sysstate:
+        name: system_state
+        type: s
+        default: ""

--- a/settings_file.py
+++ b/settings_file.py
@@ -1,2 +1,2 @@
 #!/usr/bin/python -u
-SETTINGS={'host': {'bootflags': {'default': '0000000000', 'type': 's', 'name': 'boot_flags'}, 'powercap': {'name': 'power_cap', 'min': 0, 'default': 0, 'max': 1000, 'type': 'i', 'unit': 'watts'}}}
+SETTINGS={'host': {'bootflags': {'default': '0000000000', 'type': 's', 'name': 'boot_flags'}, 'powercap': {'name': 'power_cap', 'min': 0, 'default': 0, 'max': 1000, 'type': 'i', 'unit': 'watts'}, 'sysstate': {'default': '', 'type': 's', 'name': 'system_state'}}}


### PR DESCRIPTION
Add system_state property to keep track of the system
state across reboots.
Include the generated settings_file.py since some build
machines cannot have the yaml python module installed. This
file will be removed once the code is ported to C in the next rework.
Add the path where the settings will be stored in bmc:
/var/lib/obmc/
Address review comments from the initial commit.