### PR TITLE
Change default for boot parms to be human readable

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -11,7 +11,7 @@ host:
     bootflags:
         name: boot_flags
         type: s
-        default: "0000000000"
+        default: "default"
     sysstate:
         name: system_state
         type: s

--- a/settings_file.py
+++ b/settings_file.py
@@ -1,2 +1,2 @@
 #!/usr/bin/python -u
-SETTINGS={'host': {'bootflags': {'default': '0000000000', 'type': 's', 'name': 'boot_flags'}, 'powercap': {'name': 'power_cap', 'min': 0, 'default': 0, 'max': 1000, 'type': 'i', 'unit': 'watts'}, 'sysstate': {'default': '', 'type': 's', 'name': 'system_state'}}}
+SETTINGS={'host': {'bootflags': {'default': 'default', 'type': 's', 'name': 'boot_flags'}, 'powercap': {'name': 'power_cap', 'min': 0, 'default': 0, 'max': 1000, 'type': 'i', 'unit': 'watts'}, 'sysstate': {'default': '', 'type': 's', 'name': 'system_state'}}}


### PR DESCRIPTION
The REST interface is not a reflection of IPMI.  It is its own
design.  The 0's as the default was because that is what the
you could think of as the IPMI bytes indicating default. The
OpenBMC REST interface should not have a direct relationship
with IPMI.  That is a general tenent