### PR TITLE
Use pyphosphor rather than skeleton Openbmc.py

### DIFF
--- a/settings_manager.py
+++ b/settings_manager.py
@@ -6,16 +6,16 @@ import dbus.service
 import dbus.mainloop.glib
 import os
 import os.path as path
-import Openbmc
+from obmc.dbuslib.bindings import DbusProperties, get_dbus
 import settings_file as s
 
 DBUS_NAME = 'org.openbmc.settings.Host'
 OBJ_NAME = '/org/openbmc/settings/host0'
 CONTROL_INTF = 'org.openbmc.Settings'
 
-class HostSettingsObject(Openbmc.DbusProperties):
+class HostSettingsObject(DbusProperties):
     def __init__(self, bus, name, settings, path):
-        Openbmc.DbusProperties.__init__(self)
+        DbusProperties.__init__(self)
         dbus.service.Object.__init__(self, bus, name)
 
         self.path = path
@@ -79,7 +79,7 @@ class HostSettingsObject(Openbmc.DbusProperties):
 if __name__ == '__main__':
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
-    bus = Openbmc.getDBus()
+    bus = get_dbus()
     name = dbus.service.BusName(DBUS_NAME, bus)
     obj = HostSettingsObject(bus, OBJ_NAME, s.SETTINGS, "/var/lib/obmc/")
     mainloop = gobject.MainLoop()


### PR DESCRIPTION
The Openbmc module in skeleton is going away so move to using the
bindings add ons in the pyphosphor package.

Signed-of-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-settingsd/10)
<!-- Reviewable:end -->
